### PR TITLE
Delete .bundle directory

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,0 @@
----
-BUNDLE_PATH: "/home/runner/work/wai-aria-practices/wai-aria-practices/vendor/bundle"
-BUNDLE_DEPLOYMENT: "true"
-BUNDLE_JOBS: "4"


### PR DESCRIPTION
Remove `.bundle/config` as it may conflict with `bundle install` step listed in README. This is due to BUNDLE_PATH coming from automated build.

cc @isaacdurazo