### PR TITLE
Revert Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,8 +98,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.8.0)
     multipart-post (2.1.1)
-    nokogiri (1.13.6-arm64-darwin)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.22.0)
       faraday (>= 0.9)
@@ -128,7 +130,7 @@ GEM
       jekyll (>= 3.6, < 5.0)
 
 PLATFORMS
-  universal-darwin-20
+  ruby
 
 DEPENDENCIES
   nokogiri


### PR DESCRIPTION
This PR reverts the pinned platform in the `Gemfile.lock` file to `ruby`. 

`universal-darwin-20` is currently the pinned platform. This will cause workflow issues when being deployed to the currently favored target OS environment provided by Netlify (linux).