### PR TITLE
Focus for button links on homepage

### DIFF
--- a/content-assets/wai-aria-practices/homepage.css
+++ b/content-assets/wai-aria-practices/homepage.css
@@ -133,7 +133,8 @@ a.button-link {
   transition: background-color 150ms linear, color 150ms linear;
 }
 a.button-link:hover,
-a.button-link:active {
+a.button-link:active,
+a.button-link:focus {
   background: white;
   color: #185a6a;
 }
@@ -143,7 +144,8 @@ a.button-link-white {
   border: 2px solid transparent;
 }
 a.button-link-white:hover,
-a.button-link-white:active {
+a.button-link-white:active,
+a.button-link-white:focus {
   background: #eee;
   color: black;
 }


### PR DESCRIPTION
This PR resolves #122, where the "Learn More" links have visible focus.

As said in the issue, there is focus on the hero section, but it has low contrast. What is a better color combination for contrast? cc: @isaacdurazo 