### PR TITLE
Remove h2 from details element

### DIFF
--- a/ARIA/apg/example-index/accordion/accordion.md
+++ b/ARIA/apg/example-index/accordion/accordion.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/accordion/accordion
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -55,10 +55,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/alert/alert.md
+++ b/ARIA/apg/example-index/alert/alert.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/alert/alert
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/breadcrumb/index.md
+++ b/ARIA/apg/example-index/breadcrumb/index.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/breadcrumb/index
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -55,10 +55,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/button/button.md
+++ b/ARIA/apg/example-index/button/button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/button/button_idl.md
+++ b/ARIA/apg/example-index/button/button_idl.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button_idl
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
+++ b/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-1-prev-next
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/carousel/carousel-2-tablist.md
+++ b/ARIA/apg/example-index/carousel/carousel-2-tablist.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-2-tablist
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/checkbox/checkbox-mixed.md
+++ b/ARIA/apg/example-index/checkbox/checkbox-mixed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox-mixed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/checkbox/checkbox.md
+++ b/ARIA/apg/example-index/checkbox/checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 18 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-both
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-list
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-none
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/combobox-datepicker.md
+++ b/ARIA/apg/example-index/combobox/combobox-datepicker.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-datepicker
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -62,10 +62,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/combobox-select-only.md
+++ b/ARIA/apg/example-index/combobox/combobox-select-only.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-select-only
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 10 February 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/combobox/grid-combo.md
+++ b/ARIA/apg/example-index/combobox/grid-combo.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/grid-combo
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 10 February 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -58,10 +58,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/dialog-modal/alertdialog.md
+++ b/ARIA/apg/example-index/dialog-modal/alertdialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/alertdialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -59,10 +59,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/datepicker-dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 18 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -62,10 +62,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/dialog-modal/dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -57,10 +57,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/disclosure/disclosure-faq.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-faq.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-faq
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/disclosure/disclosure-image-description.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-image-description.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-image-description
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/feed/feed.md
+++ b/ARIA/apg/example-index/feed/feed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/feed/feed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -53,10 +53,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/grid/LayoutGrids.md
+++ b/ARIA/apg/example-index/grid/LayoutGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/LayoutGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -58,10 +58,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/grid/advancedDataGrid.md
+++ b/ARIA/apg/example-index/grid/advancedDataGrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/advancedDataGrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -60,10 +60,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/grid/dataGrids.md
+++ b/ARIA/apg/example-index/grid/dataGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/dataGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -60,10 +60,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/js/notice.html
+++ b/ARIA/apg/example-index/js/notice.html
@@ -5,7 +5,6 @@
 <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/link/link.md
+++ b/ARIA/apg/example-index/link/link.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/link/link
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/listbox/listbox-collapsible.md
+++ b/ARIA/apg/example-index/listbox/listbox-collapsible.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-collapsible
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 10 February 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -58,10 +58,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/listbox/listbox-grouped.md
+++ b/ARIA/apg/example-index/listbox/listbox-grouped.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-grouped
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -58,10 +58,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
+++ b/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-rearrangeable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -59,10 +59,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/listbox/listbox-scrollable.md
+++ b/ARIA/apg/example-index/listbox/listbox-scrollable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-scrollable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -58,10 +58,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions-active-descen
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -59,10 +59,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/menu-button/menu-button-actions.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/menu-button/menu-button-links.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-links.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-links
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/menubar/menubar-editor.md
+++ b/ARIA/apg/example-index/menubar/menubar-editor.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-editor
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -57,10 +57,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/menubar/menubar-navigation.md
+++ b/ARIA/apg/example-index/menubar/menubar-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/meter/meter.md
+++ b/ARIA/apg/example-index/meter/meter.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/meter/meter
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -63,10 +63,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/radio/radio-activedescendant.md
+++ b/ARIA/apg/example-index/radio/radio-activedescendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-activedescendant
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/radio/radio-rating.md
+++ b/ARIA/apg/example-index/radio/radio-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/radio/radio.md
+++ b/ARIA/apg/example-index/radio/radio.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/slider/slider-color-viewer.md
+++ b/ARIA/apg/example-index/slider/slider-color-viewer.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-color-viewer
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/slider/slider-multithumb.md
+++ b/ARIA/apg/example-index/slider/slider-multithumb.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-multithumb
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/slider/slider-rating.md
+++ b/ARIA/apg/example-index/slider/slider-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/slider/slider-seek.md
+++ b/ARIA/apg/example-index/slider/slider-seek.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-seek
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/slider/slider-temperature.md
+++ b/ARIA/apg/example-index/slider/slider-temperature.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-temperature
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
+++ b/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/spinbutton/datepicker-spinbuttons
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -64,10 +64,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/switch/switch-button.md
+++ b/ARIA/apg/example-index/switch/switch-button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/switch/switch-checkbox.md
+++ b/ARIA/apg/example-index/switch/switch-checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 10 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/switch/switch.md
+++ b/ARIA/apg/example-index/switch/switch.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/table/sortable-table.md
+++ b/ARIA/apg/example-index/table/sortable-table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/sortable-table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -57,10 +57,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/table/table.md
+++ b/ARIA/apg/example-index/table/table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -55,10 +55,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/tabs/tabs-automatic.md
+++ b/ARIA/apg/example-index/tabs/tabs-automatic.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-automatic
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 22 March 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/tabs/tabs-manual.md
+++ b/ARIA/apg/example-index/tabs/tabs-manual.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-manual
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 22 March 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/toolbar/toolbar.md
+++ b/ARIA/apg/example-index/toolbar/toolbar.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/toolbar/toolbar
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -69,10 +69,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/treegrid/treegrid-1.md
+++ b/ARIA/apg/example-index/treegrid/treegrid-1.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treegrid/treegrid-1
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 10 February 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -77,10 +77,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1a
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -65,10 +65,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1b
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 23 November 2021</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -65,10 +65,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/ARIA/apg/example-index/treeview/treeview-navigation.md
+++ b/ARIA/apg/example-index/treeview/treeview-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 22 June 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 16 May 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG
@@ -56,10 +56,10 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
+            <h2 id="support-notice-header">Read This First</h2>
             <details id="support-notice" class="note">
     
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.

--- a/content-assets/wai-aria-practices/styles.css
+++ b/content-assets/wai-aria-practices/styles.css
@@ -629,15 +629,16 @@ table.sortable th button:focus {
 #support-notice h2, #support-notice > * {
   color: #60470C;
 }
+
 #support-notice > * {
   padding-left: var(--left-right-padding);
   padding-right: var(--left-right-padding);
 }
-#support-notice h2 {
-  font-size: 1em;
-  border-bottom: none;
-  margin: 0;
+
+#support-notice-header {
+  color: #60470C;
 }
+
 #support-notice summary {
   background-color: #FCEBC3;
   padding-top: 1em;
@@ -684,6 +685,7 @@ table.sortable th button:focus {
   padding-top: 1em;
 }
 #support-notice summary > :last-child {
+  margin-top: 0;
   margin-bottom: 0;
 }
 #support-notice ul {

--- a/content/index.md
+++ b/content/index.md
@@ -53,11 +53,13 @@ lang: en
           <div class="top-box">
             <div class="top-detail-1 detail-1"></div>
             <div class="detail-2"></div>
-            <h1>ARIA Authoring Practices Guide (APG) Home</h1>
+            <h1>ARIA Authoring Practices Guide Home</h1>
             <p>
-        Learn to use the accessibility semantics defined by the Accessible Rich Internet Application (ARIA) specification to create accessible web experiences.
+        Learn to use the accessibility semantics defined by ARIA 
+        to create accessible rich internet applications.
         This guide describes how to apply accessibility semantics to common design patterns and widgets.
-        It provides design patterns and functional examples complemented by in-depth guidance for fundamental practices.
+        It provides design patterns and functional examples
+        complemented by in-depth guidance for fundamental practices.
       </p>
             <a href="patterns/" class="button-link button-link-white">View Patterns</a>
           </div>
@@ -76,14 +78,15 @@ lang: en
       <div class="contained margin-fix">
         <div class="resource-item">
                 <div class="resource-item-content">
-                  <h3>Design Patterns and Examples</h3>
+                  <h3>Design Patterns and Widgets</h3>
                   <p>
                     
-            Learn how to make accessible web components and widgets with ARIA roles, states and properties and by implementing keyboard support.
-            One or more ways of implementing each pattern is demonstrated with a functional example.
+            Learn how to make common rich internet application patterns and
+            widgets accessible by applying WAI-ARIA roles, states and
+            properties, and implementing keyboard support.
           
                   </p>
-                  <a href="patterns/" aria-label="Learn more about APG patterns and examples" class="button-link">Learn More</a>
+                  <a href="patterns/" aria-label="View patterns" class="button-link">Learn More</a>
                 </div>
                 <div class="resource-item-img">
                   <img alt="A menagerie of widgets." src="{{ '/content-images/wai-aria-practices/generated/index-2.svg' | relative_url }}">
@@ -98,7 +101,7 @@ lang: en
             meaning of the layout of a page.
           
                   </p>
-                  <a href="practices/landmark-regions/" aria-label="Learn more about ARIA landmarks" class="button-link">Learn More</a>
+                  <a href="practices/landmark-regions/" aria-label="View landmarks guide" class="button-link">Learn More</a>
                 </div>
                 <div class="resource-item-img">
                   <img alt="A document flies apart into chunks." src="{{ '/content-images/wai-aria-practices/generated/index-3.svg' | relative_url }}">
@@ -114,7 +117,7 @@ lang: en
             experiences.
           
                   </p>
-                  <a href="practices/names-and-descriptions/" aria-label="Learn more about accessible names and descriptions" class="button-link">Learn More</a>
+                  <a href="practices/names-and-descriptions/" aria-label="View names and descriptions guide" class="button-link">Learn More</a>
                 </div>
                 <div class="resource-item-img">
                   <img alt="Indicators delve inside a document." src="{{ '/content-images/wai-aria-practices/generated/index-4.svg' | relative_url }}">
@@ -128,7 +131,7 @@ lang: en
             developing keyboard interfaces, and more.
           
                   </p>
-                  <a class="button-link" href="practices/" aria-label="Learn more about APG practices">Learn More</a>
+                  <a class="button-link" href="practices/" aria-label="View practices">Learn More</a>
                 </div>
                 <div class="resource-item-img">
                   <img alt="A box with an accessibility label is chock full of widgets and document bits." src="{{ '/content-images/wai-aria-practices/generated/index-5.svg' | relative_url }}">
@@ -268,16 +271,16 @@ lang: en
           <div>
             <h3>Mailing Lists</h3>
             <p>
-            The APG Task Force uses the public aria-practices mailing list for email discussion. 
-            Meeting announcements, agendas, and links to minutes are sent to the mailing list.
-            While GitHub issues are the preferred place to discuss APG content, the mailing list is available to anyone who would prefer to communicate with the APG Task Force via email.
-          </p><p>
-            <a rel="noopener noreferrer"
+            The APG Task Force uses the public-aria-practices@w3.org mailing
+            list
+            
+            <span>(<a rel="noopener noreferrer"
               target="_blank"
               href="https://lists.w3.org/Archives/Public/public-aria-practices/"
-            >
-              View the aria-practices mailing list archive
-            </a>
+              >view the mailing list archive</a>)</span>
+            for email discussion. 
+            Meeting announcements, agendas, and links to minutes are sent to the mailing list.
+            While GitHub issues are the preferred place to discuss APG content, the mailing list is available to anyone who would prefer to communicate with the APG Task Force via email.
           </p>
           </div>
         </div>

--- a/scripts/pre-build/library/loadExamples/handleElement.js
+++ b/scripts/pre-build/library/loadExamples/handleElement.js
@@ -56,6 +56,7 @@ const getHandleElement =
         element.insertAdjacentHTML(
           "afterbegin",
           `
+            <h2 id="support-notice-header">Read This First</h2>
             ${notice}
             <h2>About This Example</h2>
           `

--- a/scripts/pre-build/library/loadExamples/loadExamples.js
+++ b/scripts/pre-build/library/loadExamples/loadExamples.js
@@ -90,7 +90,6 @@ const loadExamples = async () => {
         "<summary>Important Note About Use of This Example</summary>",
       replacementText: `
         <summary>
-          <h2>Important Note About Use of This Example</h2>
           <p>
             The code in this example is not intended for production environments. 
             Before using it for any purpose, read this to understand why.


### PR DESCRIPTION
This PR implements the solution in [this comment ](https://github.com/w3c/wai-aria-practices/issues/116#issuecomment-1163479293) in #116.

The H2 element was removed from the details element.