### PR TITLE
For publication/deploy on Thursday 3 November 2022

### DIFF
--- a/ARIA/apg/example-index/accordion/accordion.md
+++ b/ARIA/apg/example-index/accordion/accordion.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/accordion/accordion
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/accordion/accordion.md
+++ b/ARIA/apg/example-index/accordion/accordion.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/accordion/accordion
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/8'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/alert/alert.md
+++ b/ARIA/apg/example-index/alert/alert.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/alert/alert
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/alert/alert.md
+++ b/ARIA/apg/example-index/alert/alert.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/alert/alert
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/breadcrumb/index.md
+++ b/ARIA/apg/example-index/breadcrumb/index.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/breadcrumb/index
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/breadcrumb/index.md
+++ b/ARIA/apg/example-index/breadcrumb/index.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/breadcrumb/index
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/button/button.md
+++ b/ARIA/apg/example-index/button/button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/button/button.md
+++ b/ARIA/apg/example-index/button/button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/button/button_idl.md
+++ b/ARIA/apg/example-index/button/button_idl.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button_idl
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/button/button_idl.md
+++ b/ARIA/apg/example-index/button/button_idl.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/button/button_idl
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
+++ b/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-1-prev-next
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
+++ b/ARIA/apg/example-index/carousel/carousel-1-prev-next.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-1-prev-next
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/carousel/carousel-2-tablist.md
+++ b/ARIA/apg/example-index/carousel/carousel-2-tablist.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-2-tablist
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/carousel/carousel-2-tablist.md
+++ b/ARIA/apg/example-index/carousel/carousel-2-tablist.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/carousel/carousel-2-tablist
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/10'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/checkbox/checkbox-mixed.md
+++ b/ARIA/apg/example-index/checkbox/checkbox-mixed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox-mixed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/checkbox/checkbox-mixed.md
+++ b/ARIA/apg/example-index/checkbox/checkbox-mixed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox-mixed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/checkbox/checkbox.md
+++ b/ARIA/apg/example-index/checkbox/checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/checkbox/checkbox.md
+++ b/ARIA/apg/example-index/checkbox/checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/checkbox/checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/9'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-both
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-both.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-both
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-list
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-list.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-list
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-none
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
+++ b/ARIA/apg/example-index/combobox/combobox-autocomplete-none.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-autocomplete-none
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-datepicker.md
+++ b/ARIA/apg/example-index/combobox/combobox-datepicker.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-datepicker
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-datepicker.md
+++ b/ARIA/apg/example-index/combobox/combobox-datepicker.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-datepicker
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-select-only.md
+++ b/ARIA/apg/example-index/combobox/combobox-select-only.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-select-only
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/combobox-select-only.md
+++ b/ARIA/apg/example-index/combobox/combobox-select-only.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/combobox-select-only
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/grid-combo.md
+++ b/ARIA/apg/example-index/combobox/grid-combo.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/grid-combo
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/combobox/grid-combo.md
+++ b/ARIA/apg/example-index/combobox/grid-combo.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/combobox/grid-combo
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/7'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/alertdialog.md
+++ b/ARIA/apg/example-index/dialog-modal/alertdialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/alertdialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/alertdialog.md
+++ b/ARIA/apg/example-index/dialog-modal/alertdialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/alertdialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/20'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/datepicker-dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/datepicker-dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/datepicker-dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/27'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/dialog-modal/dialog.md
+++ b/ARIA/apg/example-index/dialog-modal/dialog.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/dialog-modal/dialog
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/6'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-faq.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-faq.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-faq
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-faq.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-faq.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-faq
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-image-description.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-image-description.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-image-description
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-image-description.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-image-description.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-image-description
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation-hybrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/disclosure/disclosure-navigation.md
+++ b/ARIA/apg/example-index/disclosure/disclosure-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/disclosure/disclosure-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/feed/feed.md
+++ b/ARIA/apg/example-index/feed/feed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/feed/feed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/feed/feed.md
+++ b/ARIA/apg/example-index/feed/feed.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/feed/feed
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/19'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/LayoutGrids.md
+++ b/ARIA/apg/example-index/grid/LayoutGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/LayoutGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/LayoutGrids.md
+++ b/ARIA/apg/example-index/grid/LayoutGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/LayoutGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/advancedDataGrid.md
+++ b/ARIA/apg/example-index/grid/advancedDataGrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/advancedDataGrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/advancedDataGrid.md
+++ b/ARIA/apg/example-index/grid/advancedDataGrid.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/advancedDataGrid
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/dataGrids.md
+++ b/ARIA/apg/example-index/grid/dataGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/dataGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/grid/dataGrids.md
+++ b/ARIA/apg/example-index/grid/dataGrids.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/grid/dataGrids
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/15'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/landmarks/css/common.css
+++ b/ARIA/apg/example-index/landmarks/css/common.css
@@ -82,7 +82,7 @@ aside a {
   text-decoration: underline;
 }
 
-main p a {
+main a {
   text-decoration: underline;
 }
 

--- a/ARIA/apg/example-index/landmarks/main.html
+++ b/ARIA/apg/example-index/landmarks/main.html
@@ -6,7 +6,6 @@
     <link href="css/bootstrap.css" rel="stylesheet" media="screen">
     <link href="css/bootstrap-theme.css" rel="stylesheet" media="screen">
     <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
-    <link href="css/bootstrap-accessibility.css" rel="stylesheet" media="screen">
     <link href="css/visua11y.css" rel="stylesheet" media="screen">
     <link href="css/common.css" rel="stylesheet" media="screen">
   </head>

--- a/ARIA/apg/example-index/landmarks/resources.html
+++ b/ARIA/apg/example-index/landmarks/resources.html
@@ -64,9 +64,9 @@
 
                           <ul>
                             <li><a href="http://matatk.agrip.org.uk/landmarks/">Landmarks Browser Extension</a></li>
-                            <li><a href="http://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
+                            <li><a href="https://accessibility-bookmarklets.org/">Accessibility Bookmarklets: Landmark Bookmarklet</a></li>
                             <li><a href="http://whatsock.com/training/matrices/visual-aria.htm">The Visual ARIA Bookmarklet</a></li>
-                            <li><a href="https://github.com/paypal/skipto#readme">SkipTo, version 4.1</a> (PayPal/Illinois)</li>
+                            <li><a href="https://skipto-landmarks-headings.github.io">SkipTo Browser Extension and Page Scripts</a></li>
                             <li><a href="https://addons.mozilla.org/en-US/firefox/addon/ainspector-wcag/">AInspector WCAG for Firefox</a> (Landmark Rule Category)</li>
                             <li><a href="https://fae.disability.illinois.edu/">Functional Accessibility Evaluator 2.2</a> (Landmark Rule Category)</li>
                           </ul>

--- a/ARIA/apg/example-index/link/link.md
+++ b/ARIA/apg/example-index/link/link.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/link/link
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/link/link.md
+++ b/ARIA/apg/example-index/link/link.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/link/link
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/21'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-collapsible.md
+++ b/ARIA/apg/example-index/listbox/listbox-collapsible.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-collapsible
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-collapsible.md
+++ b/ARIA/apg/example-index/listbox/listbox-collapsible.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-collapsible
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-grouped.md
+++ b/ARIA/apg/example-index/listbox/listbox-grouped.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-grouped
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-grouped.md
+++ b/ARIA/apg/example-index/listbox/listbox-grouped.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-grouped
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
+++ b/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-rearrangeable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
+++ b/ARIA/apg/example-index/listbox/listbox-rearrangeable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-rearrangeable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-scrollable.md
+++ b/ARIA/apg/example-index/listbox/listbox-scrollable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-scrollable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/listbox/listbox-scrollable.md
+++ b/ARIA/apg/example-index/listbox/listbox-scrollable.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/listbox/listbox-scrollable
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/13'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions-active-descen
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions-active-descendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions-active-descen
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-actions.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-actions.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-actions.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-actions
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-links.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-links.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-links
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menu-button/menu-button-links.md
+++ b/ARIA/apg/example-index/menu-button/menu-button-links.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menu-button/menu-button-links
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menubar/menubar-editor.md
+++ b/ARIA/apg/example-index/menubar/menubar-editor.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-editor
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menubar/menubar-editor.md
+++ b/ARIA/apg/example-index/menubar/menubar-editor.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-editor
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menubar/menubar-navigation.md
+++ b/ARIA/apg/example-index/menubar/menubar-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/menubar/menubar-navigation.md
+++ b/ARIA/apg/example-index/menubar/menubar-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/menubar/menubar-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/5'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/meter/meter.md
+++ b/ARIA/apg/example-index/meter/meter.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/meter/meter
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/meter/meter.md
+++ b/ARIA/apg/example-index/meter/meter.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/meter/meter
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/30'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio-activedescendant.md
+++ b/ARIA/apg/example-index/radio/radio-activedescendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-activedescendant
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio-activedescendant.md
+++ b/ARIA/apg/example-index/radio/radio-activedescendant.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-activedescendant
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio-rating.md
+++ b/ARIA/apg/example-index/radio/radio-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio-rating.md
+++ b/ARIA/apg/example-index/radio/radio-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio.md
+++ b/ARIA/apg/example-index/radio/radio.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/radio/radio.md
+++ b/ARIA/apg/example-index/radio/radio.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/radio/radio
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/22'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-color-viewer.md
+++ b/ARIA/apg/example-index/slider/slider-color-viewer.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-color-viewer
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-color-viewer.md
+++ b/ARIA/apg/example-index/slider/slider-color-viewer.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-color-viewer
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-multithumb.md
+++ b/ARIA/apg/example-index/slider/slider-multithumb.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-multithumb
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-multithumb.md
+++ b/ARIA/apg/example-index/slider/slider-multithumb.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-multithumb
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-rating.md
+++ b/ARIA/apg/example-index/slider/slider-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-rating.md
+++ b/ARIA/apg/example-index/slider/slider-rating.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-rating
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-seek.md
+++ b/ARIA/apg/example-index/slider/slider-seek.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-seek
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-seek.md
+++ b/ARIA/apg/example-index/slider/slider-seek.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-seek
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-temperature.md
+++ b/ARIA/apg/example-index/slider/slider-temperature.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-temperature
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/slider/slider-temperature.md
+++ b/ARIA/apg/example-index/slider/slider-temperature.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/slider/slider-temperature
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/3'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
+++ b/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/spinbutton/datepicker-spinbuttons
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
+++ b/ARIA/apg/example-index/spinbutton/datepicker-spinbuttons.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/spinbutton/datepicker-spinbuttons
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/14'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch-button.md
+++ b/ARIA/apg/example-index/switch/switch-button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch-button.md
+++ b/ARIA/apg/example-index/switch/switch-button.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-button
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch-checkbox.md
+++ b/ARIA/apg/example-index/switch/switch-checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch-checkbox.md
+++ b/ARIA/apg/example-index/switch/switch-checkbox.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch-checkbox
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch.md
+++ b/ARIA/apg/example-index/switch/switch.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/switch/switch.md
+++ b/ARIA/apg/example-index/switch/switch.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/switch/switch
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/2'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/table/sortable-table.md
+++ b/ARIA/apg/example-index/table/sortable-table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/sortable-table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/table/sortable-table.md
+++ b/ARIA/apg/example-index/table/sortable-table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/sortable-table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/table/table.md
+++ b/ARIA/apg/example-index/table/table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/table/table.md
+++ b/ARIA/apg/example-index/table/table.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/table/table
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/16'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/tabs/tabs-automatic.md
+++ b/ARIA/apg/example-index/tabs/tabs-automatic.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-automatic
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/tabs/tabs-automatic.md
+++ b/ARIA/apg/example-index/tabs/tabs-automatic.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-automatic
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/tabs/tabs-manual.md
+++ b/ARIA/apg/example-index/tabs/tabs-manual.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-manual
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/tabs/tabs-manual.md
+++ b/ARIA/apg/example-index/tabs/tabs-manual.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/tabs/tabs-manual
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/11'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/toolbar/toolbar.md
+++ b/ARIA/apg/example-index/toolbar/toolbar.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/toolbar/toolbar
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/toolbar/toolbar.md
+++ b/ARIA/apg/example-index/toolbar/toolbar.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/toolbar/toolbar
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/18'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treegrid/treegrid-1.md
+++ b/ARIA/apg/example-index/treegrid/treegrid-1.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treegrid/treegrid-1
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treegrid/treegrid-1.md
+++ b/ARIA/apg/example-index/treegrid/treegrid-1.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treegrid/treegrid-1
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1a
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1a.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1a
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1b
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
+++ b/ARIA/apg/example-index/treeview/treeview-1/treeview-1b.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-1/treeview-1b
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-navigation.md
+++ b/ARIA/apg/example-index/treeview/treeview-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 31 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/ARIA/apg/example-index/treeview/treeview-navigation.md
+++ b/ARIA/apg/example-index/treeview/treeview-navigation.md
@@ -12,7 +12,7 @@ permalink: /ARIA/apg/example-index/treeview/treeview-navigation
 
 sidebar: true
 
-footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 4 October 2022</p>          </div>        "
+footer: "          <div class='example-page-footer'>            <p><a href='https://github.com/w3c/aria-practices/projects/17'>View issues related to this example</a></p>            <p>Page last updated: 6 October 2022</p>          </div>        "
 
 # Context here: https://github.com/w3c/wai-aria-practices/issues/31
 type_of_guidance: APG

--- a/_html/aria-practices.html
+++ b/_html/aria-practices.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
-<meta name="generator" content="ReSpec 32.2.5">
+<meta name="generator" content="ReSpec 32.3.0">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
 .issue-label{text-transform:initial}
@@ -269,15 +269,15 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "aliasOf": "WAI-ARIA-1.1"
     }
   },
-  "publishISODate": "2022-10-06T00:00:00.000Z",
-  "generatedSubtitle": "W3C Editor's Draft 06 October 2022"
+  "publishISODate": "2022-10-31T00:00:00.000Z",
+  "generatedSubtitle": "W3C Editor's Draft 31 October 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED"></head>
 <body class="h-entry informative"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">WAI-ARIA Authoring Practices 1.2</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2022-10-06">06 October 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2022-10-31">31 October 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -7674,7 +7674,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </ul>
     </section>
 
-    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-8619825484288866" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
+    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-03361303330875054" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
 
   </section>
 
@@ -7684,7 +7684,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
     <dl class="bibliography"><dt id="bib-html">[HTML]</dt><dd>
       <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
     </dd><dt id="bib-html-aam">[HTML-AAM]</dt><dd>
-      <a href="https://www.w3.org/TR/html-aam-1.0/"><cite>HTML Accessibility API Mappings 1.0</cite></a>. Steve Faulkner; Scott O'Hara.  W3C. 4 October 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/html-aam-1.0/">https://www.w3.org/TR/html-aam-1.0/</a>
+      <a href="https://www.w3.org/TR/html-aam-1.0/"><cite>HTML Accessibility API Mappings 1.0</cite></a>. Steve Faulkner; Scott O'Hara.  W3C. 26 October 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/html-aam-1.0/">https://www.w3.org/TR/html-aam-1.0/</a>
     </dd><dt id="bib-html-aria">[HTML-ARIA]</dt><dd>
       <a href="https://www.w3.org/TR/html-aria/"><cite>ARIA in HTML</cite></a>. Steve Faulkner; Scott O'Hara; Patrick Lauke.  W3C. 27 September 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/html-aria/">https://www.w3.org/TR/html-aria/</a>
     </dd><dt id="bib-svg2">[SVG2]</dt><dd>

--- a/_html/aria-practices.html
+++ b/_html/aria-practices.html
@@ -269,15 +269,15 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       "aliasOf": "WAI-ARIA-1.1"
     }
   },
-  "publishISODate": "2022-10-04T00:00:00.000Z",
-  "generatedSubtitle": "W3C Editor's Draft 04 October 2022"
+  "publishISODate": "2022-10-06T00:00:00.000Z",
+  "generatedSubtitle": "W3C Editor's Draft 06 October 2022"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED"></head>
 <body class="h-entry informative"><div class="head">
     <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
   </a></p>
     <h1 id="title" class="title">WAI-ARIA Authoring Practices 1.2</h1> 
-    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2022-10-04">04 October 2022</time></p>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2022-10-06">06 October 2022</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -7595,9 +7595,10 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
     
     <section id="honorary-editor"><div class="header-wrapper"><h3 id="c-1-honorary-editor"><bdi class="secno">C.1 </bdi>Honorary Editor</h3><a class="self-link" href="#honorary-editor" aria-label="Permalink for Appendix C.1"></a></div>
       
-      <p>This version of the ARIA Authoring Practice Guide is dedicated to the memory of 
-        Carolyn MacLeod whose contributions our Task Force sees throughout Authoring Practice Guides. 
-        She was  dedicated to all aspects of the ARIA Authoring Practice Guide from suggesting editorial edits for the clarification to testing APG examples with assistive technologies.</p>
+      <p>
+        This version of the ARIA Authoring Practices Guide is dedicated to the memory of Carolyn MacLeod whose contributions are visible  throughout the entire guide.
+        She was dedicated to all aspects of the work of the APG Task Force from writing code and suggesting editorial revisions to testing  examples with assistive technologies.
+      </p>
       <ul>
         <li>Carolyn MacLeod (IBM Canada)</li>
       </ul>
@@ -7673,7 +7674,7 @@ So, As advised by <a href="#naming_rule_avoid_fallback">Rule 4: Avoid Browser Fa
       </ul>
     </section>
 
-    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-5473305503667893" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
+    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-8619825484288866" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
 
   </section>
 

--- a/content-assets/wai-aria-practices/homepage.css
+++ b/content-assets/wai-aria-practices/homepage.css
@@ -300,6 +300,7 @@ h2 + h3 + p {
   text-decoration: none;
   color: #215a9c;
   font-weight: bold;
+  display: block;
 }
 .work-item a:after,
 .collaboration-item:not(.mailing-list-item) a:after {
@@ -364,6 +365,10 @@ h2 + h3 + p {
 }
 .collaboration-item {
   margin: 0 auto;
+}
+.collaboration-item a,
+.collaboration-item p {
+    text-align: left;
 }
 .collaboration-item:not(.mailing-list-item) img {
   margin-bottom: 15px;

--- a/content/about.md
+++ b/content/about.md
@@ -152,9 +152,10 @@ lang: en
     
     <section id="honorary-editor"><div class="header-wrapper"><h3 id="c-1-honorary-editor">Honorary Editor</h3></div>
       
-      <p>This version of the ARIA Authoring Practice Guide is dedicated to the memory of 
-        Carolyn MacLeod whose contributions our Task Force sees throughout Authoring Practice Guides. 
-        She was  dedicated to all aspects of the ARIA Authoring Practice Guide from suggesting editorial edits for the clarification to testing APG examples with assistive technologies.</p>
+      <p>
+        This version of the ARIA Authoring Practices Guide is dedicated to the memory of Carolyn MacLeod whose contributions are visible  throughout the entire guide.
+        She was dedicated to all aspects of the work of the APG Task Force from writing code and suggesting editorial revisions to testing  examples with assistive technologies.
+      </p>
       <ul>
         <li>Carolyn MacLeod (IBM Canada)</li>
       </ul>
@@ -230,7 +231,7 @@ lang: en
       </ul>
     </section>
 
-    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-5473305503667893" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
+    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-8619825484288866" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
 
   </section>
         <section id="references" class="appendix"><div class="header-wrapper"><h2 id="d-references">References</h2></div><section id="informative-references"><div class="header-wrapper"><h3 id="d-1-informative-references">Informative references</h3></div>

--- a/content/about.md
+++ b/content/about.md
@@ -231,7 +231,7 @@ lang: en
       </ul>
     </section>
 
-    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-8619825484288866" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
+    <div data-include="common/acknowledgements/funders.html" data-include-replace="true" data-include-id="include-03361303330875054" class="respec-offending-element" title="`data-include` failed: `common/acknowledgements/funders.html` (Failed to fetch)." id="respec-offender-data-include-failed-common-acknowledgements-funders-html-failed-to-fetch"></div>
 
   </section>
         <section id="references" class="appendix"><div class="header-wrapper"><h2 id="d-references">References</h2></div><section id="informative-references"><div class="header-wrapper"><h3 id="d-1-informative-references">Informative references</h3></div>
@@ -239,7 +239,7 @@ lang: en
     <dl class="bibliography"><dt id="bib-html">[HTML]</dt><dd>
       <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
     </dd><dt id="bib-html-aam">[HTML-AAM]</dt><dd>
-      <a href="https://www.w3.org/TR/html-aam-1.0/"><cite>HTML Accessibility API Mappings 1.0</cite></a>. Steve Faulkner; Scott O'Hara.  W3C. 4 October 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/html-aam-1.0/">https://www.w3.org/TR/html-aam-1.0/</a>
+      <a href="https://www.w3.org/TR/html-aam-1.0/"><cite>HTML Accessibility API Mappings 1.0</cite></a>. Steve Faulkner; Scott O'Hara.  W3C. 26 October 2022. W3C Working Draft. URL: <a href="https://www.w3.org/TR/html-aam-1.0/">https://www.w3.org/TR/html-aam-1.0/</a>
     </dd><dt id="bib-html-aria">[HTML-ARIA]</dt><dd>
       <a href="https://www.w3.org/TR/html-aria/"><cite>ARIA in HTML</cite></a>. Steve Faulkner; Scott O'Hara; Patrick Lauke.  W3C. 27 September 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/html-aria/">https://www.w3.org/TR/html-aria/</a>
     </dd><dt id="bib-svg2">[SVG2]</dt><dd>


### PR DESCRIPTION
Includes the following changes:

- [aria-practices PR #2509](https://github.com/w3c/aria-practices/pull/2509) Landmark Examples: Underline links in main content
- [aria-practices PR #2503](https://github.com/w3c/aria-practices/pull/2503) Infrastructure: Modify GitHub workflow to add Netlify preview links to PRs from forks

CC @shawna-slh @mcking65 @a11ydoer