### PR TITLE
Rewrite iframe source attributes in APG

### DIFF
--- a/scripts/pre-build/library/rewriteElementPaths.js
+++ b/scripts/pre-build/library/rewriteElementPaths.js
@@ -10,8 +10,9 @@ const rewriteElementPaths = async (html, { onSourcePath }) => {
   const linkTags = html.querySelectorAll("link[href]");
   const scriptTags = html.querySelectorAll("script[src]");
   const imgTags = html.querySelectorAll("img[src]");
+  const iframeTags = html.querySelectorAll("iframe[src]");
 
-  [...aTags, ...linkTags, ...scriptTags, ...imgTags].forEach((element) => {
+  [...aTags, ...linkTags, ...scriptTags, ...imgTags, ...iframeTags].forEach((element) => {
     fixSpecLink(element);
 
     const href = element.getAttribute("href");


### PR DESCRIPTION
A forthcoming change to APG will add a relative-source `<iframe>` element to the APG's "Feed" example page [1]. Update the build script to transform this value using the mechanism established for other types of resources.

[1] https://github.com/w3c/aria-practices/pull/2775

---

I'm not confident that this change is valid because I haven't been able to find tests for the logic I modified. I've experimentally verified that it appears to function as intended without undesirable side effects by making some local modifications to the APG source and inspecting the result.

At the moment, it appears that all of the `<iframe>` elements in APG use absolute URLs for their `src` attributes and thus not effected by the transformation.

<details>
  <summary><code>$ find _external/aria-practices/ -type f -iname '*.html' -print0 | xargs -0 grep -i '&lt;iframe' -A2</code></summary>

    _external/aria-practices/content/patterns/button/examples/button.html:        <iframe
    _external/aria-practices/content/patterns/button/examples/button.html-          class="support-levels-command-button"
    _external/aria-practices/content/patterns/button/examples/button.html-          src="https://aria-at.w3.org/embed/reports/command-button"
    --
    _external/aria-practices/content/patterns/button/examples/button.html:        <iframe
    _external/aria-practices/content/patterns/button/examples/button.html-          class="support-levels-toggle-button"
    _external/aria-practices/content/patterns/button/examples/button.html-          src="https://aria-at.w3.org/embed/reports/toggle-button"
    --
    _external/aria-practices/content/patterns/slider/examples/slider-color-viewer.html:        <iframe
    _external/aria-practices/content/patterns/slider/examples/slider-color-viewer.html-          class="support-levels-horizontal-slider"
    _external/aria-practices/content/patterns/slider/examples/slider-color-viewer.html-          src="https://aria-at.w3.org/embed/reports/horizontal-slider"
    --
    _external/aria-practices/content/patterns/menu-button/examples/menu-button-links.html:        <iframe
    _external/aria-practices/content/patterns/menu-button/examples/menu-button-links.html-          class="support-levels-menu-button-navigation"
    _external/aria-practices/content/patterns/menu-button/examples/menu-button-links.html-          src="https://aria-at.w3.org/embed/reports/menu-button-navigation"
    --
    _external/aria-practices/content/patterns/link/examples/link.html:        <iframe
    _external/aria-practices/content/patterns/link/examples/link.html-          class="support-levels-link-span-text"
    _external/aria-practices/content/patterns/link/examples/link.html-          src="https://aria-at.w3.org/embed/reports/link-span-text"
    --
    _external/aria-practices/content/patterns/dialog-modal/examples/dialog.html:        <iframe
    _external/aria-practices/content/patterns/dialog-modal/examples/dialog.html-          class="support-levels-modal-dialog"
    _external/aria-practices/content/patterns/dialog-modal/examples/dialog.html-          src="https://aria-at.w3.org/embed/reports/modal-dialog"
    --
    _external/aria-practices/content/patterns/radio/examples/radio-activedescendant.html:        <iframe
    _external/aria-practices/content/patterns/radio/examples/radio-activedescendant.html-          class="support-levels-radiogroup-aria-activedescendant"
    _external/aria-practices/content/patterns/radio/examples/radio-activedescendant.html-          src="https://aria-at.w3.org/embed/reports/radiogroup-aria-activedescendant"
    --
    _external/aria-practices/content/patterns/alert/examples/alert.html:        <iframe
    _external/aria-practices/content/patterns/alert/examples/alert.html-          class="support-levels-alert"
    _external/aria-practices/content/patterns/alert/examples/alert.html-          src="https://aria-at.w3.org/embed/reports/alert"

</details>