### PR TITLE
Fix duplicate read this first

### DIFF
--- a/ARIA/apg/patterns/accordion/examples/accordion.md
+++ b/ARIA/apg/patterns/accordion/examples/accordion.md
@@ -63,8 +63,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -88,7 +86,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/alert/examples/alert.md
+++ b/ARIA/apg/patterns/alert/examples/alert.md
@@ -67,8 +67,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -92,7 +90,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/alertdialog/examples/alertdialog.md
+++ b/ARIA/apg/patterns/alertdialog/examples/alertdialog.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/breadcrumb/examples/breadcrumb.md
+++ b/ARIA/apg/patterns/breadcrumb/examples/breadcrumb.md
@@ -63,8 +63,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -88,7 +86,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/button/examples/button.md
+++ b/ARIA/apg/patterns/button/examples/button.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
 
     <div>

--- a/ARIA/apg/patterns/button/examples/button_idl.md
+++ b/ARIA/apg/patterns/button/examples/button_idl.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
 
     <div>

--- a/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next.md
+++ b/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next.md
@@ -66,8 +66,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -91,7 +89,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/carousel/examples/carousel-2-tablist.md
+++ b/ARIA/apg/patterns/carousel/examples/carousel-2-tablist.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/checkbox/examples/checkbox-mixed.md
+++ b/ARIA/apg/patterns/checkbox/examples/checkbox-mixed.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/checkbox/examples/checkbox.md
+++ b/ARIA/apg/patterns/checkbox/examples/checkbox.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both.md
+++ b/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-both.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list.md
+++ b/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-none.md
+++ b/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-none.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/combobox-datepicker.md
+++ b/ARIA/apg/patterns/combobox/examples/combobox-datepicker.md
@@ -70,8 +70,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -95,7 +93,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/combobox-select-only.md
+++ b/ARIA/apg/patterns/combobox/examples/combobox-select-only.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/combobox/examples/grid-combo.md
+++ b/ARIA/apg/patterns/combobox/examples/grid-combo.md
@@ -66,8 +66,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -91,7 +89,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog.md
+++ b/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog.md
@@ -70,8 +70,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -95,7 +93,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/dialog-modal/examples/dialog.md
+++ b/ARIA/apg/patterns/dialog-modal/examples/dialog.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/disclosure/examples/disclosure-faq.md
+++ b/ARIA/apg/patterns/disclosure/examples/disclosure-faq.md
@@ -66,8 +66,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -91,7 +89,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/disclosure/examples/disclosure-image-description.md
+++ b/ARIA/apg/patterns/disclosure/examples/disclosure-image-description.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid.md
+++ b/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/disclosure/examples/disclosure-navigation.md
+++ b/ARIA/apg/patterns/disclosure/examples/disclosure-navigation.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/feed/examples/feed.md
+++ b/ARIA/apg/patterns/feed/examples/feed.md
@@ -58,8 +58,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -83,7 +81,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/grid/examples/advanced-data-grid.md
+++ b/ARIA/apg/patterns/grid/examples/advanced-data-grid.md
@@ -71,8 +71,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -96,7 +94,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/grid/examples/data-grids.md
+++ b/ARIA/apg/patterns/grid/examples/data-grids.md
@@ -71,8 +71,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -96,7 +94,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/grid/examples/layout-grids.md
+++ b/ARIA/apg/patterns/grid/examples/layout-grids.md
@@ -66,8 +66,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -91,7 +89,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/link/examples/link.md
+++ b/ARIA/apg/patterns/link/examples/link.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/listbox/examples/listbox-collapsible.md
+++ b/ARIA/apg/patterns/listbox/examples/listbox-collapsible.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/listbox/examples/listbox-grouped.md
+++ b/ARIA/apg/patterns/listbox/examples/listbox-grouped.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/listbox/examples/listbox-rearrangeable.md
+++ b/ARIA/apg/patterns/listbox/examples/listbox-rearrangeable.md
@@ -66,8 +66,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -91,7 +89,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/listbox/examples/listbox-scrollable.md
+++ b/ARIA/apg/patterns/listbox/examples/listbox-scrollable.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/menu-button/examples/menu-button-actions-active-descendant.md
+++ b/ARIA/apg/patterns/menu-button/examples/menu-button-actions-active-descendant.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/menu-button/examples/menu-button-actions.md
+++ b/ARIA/apg/patterns/menu-button/examples/menu-button-actions.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/menu-button/examples/menu-button-links.md
+++ b/ARIA/apg/patterns/menu-button/examples/menu-button-links.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/menubar/examples/menubar-editor.md
+++ b/ARIA/apg/patterns/menubar/examples/menubar-editor.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/menubar/examples/menubar-navigation.md
+++ b/ARIA/apg/patterns/menubar/examples/menubar-navigation.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/meter/examples/meter.md
+++ b/ARIA/apg/patterns/meter/examples/meter.md
@@ -70,8 +70,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -95,7 +93,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/radio/examples/radio-activedescendant.md
+++ b/ARIA/apg/patterns/radio/examples/radio-activedescendant.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/radio/examples/radio-rating.md
+++ b/ARIA/apg/patterns/radio/examples/radio-rating.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/radio/examples/radio.md
+++ b/ARIA/apg/patterns/radio/examples/radio.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/slider-multithumb/examples/slider-multithumb.md
+++ b/ARIA/apg/patterns/slider-multithumb/examples/slider-multithumb.md
@@ -67,8 +67,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -92,7 +90,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/slider/examples/slider-color-viewer.md
+++ b/ARIA/apg/patterns/slider/examples/slider-color-viewer.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/slider/examples/slider-rating.md
+++ b/ARIA/apg/patterns/slider/examples/slider-rating.md
@@ -65,8 +65,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -90,7 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/slider/examples/slider-seek.md
+++ b/ARIA/apg/patterns/slider/examples/slider-seek.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/slider/examples/slider-temperature.md
+++ b/ARIA/apg/patterns/slider/examples/slider-temperature.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/spinbutton/examples/datepicker-spinbuttons.md
+++ b/ARIA/apg/patterns/spinbutton/examples/datepicker-spinbuttons.md
@@ -71,8 +71,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -96,7 +94,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/switch/examples/switch-button.md
+++ b/ARIA/apg/patterns/switch/examples/switch-button.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/switch/examples/switch-checkbox.md
+++ b/ARIA/apg/patterns/switch/examples/switch-checkbox.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/switch/examples/switch.md
+++ b/ARIA/apg/patterns/switch/examples/switch.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/table/examples/sortable-table.md
+++ b/ARIA/apg/patterns/table/examples/sortable-table.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/table/examples/table.md
+++ b/ARIA/apg/patterns/table/examples/table.md
@@ -63,8 +63,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -88,7 +86,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/tabs/examples/tabs-automatic.md
+++ b/ARIA/apg/patterns/tabs/examples/tabs-automatic.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/tabs/examples/tabs-manual.md
+++ b/ARIA/apg/patterns/tabs/examples/tabs-manual.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/toolbar/examples/toolbar.md
+++ b/ARIA/apg/patterns/toolbar/examples/toolbar.md
@@ -79,8 +79,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -104,7 +102,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/treegrid/examples/treegrid-1.md
+++ b/ARIA/apg/patterns/treegrid/examples/treegrid-1.md
@@ -88,8 +88,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -113,7 +111,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/treeview/examples/treeview-1a.md
+++ b/ARIA/apg/patterns/treeview/examples/treeview-1a.md
@@ -73,8 +73,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -98,7 +96,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/treeview/examples/treeview-1b.md
+++ b/ARIA/apg/patterns/treeview/examples/treeview-1b.md
@@ -73,8 +73,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -98,7 +96,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/ARIA/apg/patterns/treeview/examples/treeview-navigation.md
+++ b/ARIA/apg/patterns/treeview/examples/treeview-navigation.md
@@ -64,8 +64,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
   </script>
 <div>
 
-      <h2 id="support-notice-header">Read This First</h2>
-      
     <h2 id="support-notice-header">Read This First</h2>
     <details id="support-notice">
       <summary>
@@ -89,7 +87,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
       </ul>
     </details>
   
-    
     
     <div>
       

--- a/scripts/pre-build/library/transformExample.js
+++ b/scripts/pre-build/library/transformExample.js
@@ -68,13 +68,7 @@ const transformExample = async (sourcePath, sourceContents) => {
 
   const getNotice = await loadedNotice;
   const notice = await getNotice(sourcePath);
-  html.querySelector("body").insertAdjacentHTML(
-    "afterbegin",
-    `
-      <h2 id="support-notice-header">Read This First</h2>
-      ${notice}
-    `
-  );
+  html.querySelector("body").insertAdjacentHTML("afterbegin", notice);
 
   const relatedLinksElement = html.querySelector(
     '[aria-label="Related Links"]'


### PR DESCRIPTION
Fixes bug on example pages where the "Read This First" heading is duplicated. This might have been caused by conflict resolution in the transformExample.js file.