### PR TITLE
Update `transformAboutContent` to include last updated date of coverage-and-quality-report.html

### DIFF
--- a/ARIA/apg/about/coverage-and-quality/coverage-and-quality-report.md
+++ b/ARIA/apg/about/coverage-and-quality/coverage-and-quality-report.md
@@ -69,7 +69,7 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
 
   <div>
     
-    <p>Page last updated: February 13, 2024</p>
+    <p>Page last updated: 20 February 2024</p>
     <section>
       <h2>About These Reports</h2>
       <p>

--- a/ARIA/apg/about/coverage-and-quality/coverage-and-quality-report.md
+++ b/ARIA/apg/about/coverage-and-quality/coverage-and-quality-report.md
@@ -69,7 +69,7 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
 
   <div>
     
-    <p>Page last updated: 20 February 2024</p>
+    <p>Page last updated: February 20, 2024</p>
     <section>
       <h2>About These Reports</h2>
       <p>

--- a/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
+++ b/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
@@ -1,0 +1,29 @@
+const { format } = require("date-fns");
+const { rewriteRelativePath } = require("./rewritePath");
+const getFileLastModifiedDate = require("./getFileLastModifiedDate");
+
+const getExampleLastModifiedDate = async ({ html, sourcePath }) => {
+  const dependencyFilePaths = html
+    .querySelectorAll("#css_js_files a")
+    .map(
+      (link) =>
+        rewriteRelativePath(link.getAttribute("href"), {
+          onSourcePath: sourcePath,
+        }).sourcePath
+    )
+    .concat(sourcePath);
+
+  const dates = await Promise.all(
+    dependencyFilePaths.map((filePath) => getFileLastModifiedDate(filePath))
+  );
+
+  dates.sort((a, b) => b - a);
+
+  const mostRecent = dates[0];
+
+  const dateFormatted = format(mostRecent, "d MMMM y");
+
+  return dateFormatted;
+};
+
+module.exports = getExampleLastModifiedDate;

--- a/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
+++ b/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
@@ -1,29 +1,11 @@
 const { format } = require("date-fns");
-const { rewriteRelativePath } = require("./rewritePath");
 const getFileLastModifiedDate = require("./getFileLastModifiedDate");
 
-const getExampleLastModifiedDate = async ({ html, sourcePath }) => {
-  const dependencyFilePaths = html
-    .querySelectorAll("#css_js_files a")
-    .map(
-      (link) =>
-        rewriteRelativePath(link.getAttribute("href"), {
-          onSourcePath: sourcePath,
-        }).sourcePath
-    )
-    .concat(sourcePath);
-
-  const dates = await Promise.all(
-    dependencyFilePaths.map((filePath) => getFileLastModifiedDate(filePath))
-  );
-
-  dates.sort((a, b) => b - a);
-
-  const mostRecent = dates[0];
-
-  const dateFormatted = format(mostRecent, "d MMMM y");
+const getCoverageAndQualityLastModifiedDate = async (sourcePath) => {
+  const date = await getFileLastModifiedDate(sourcePath);
+  const dateFormatted = format(date, "d MMMM y");
 
   return dateFormatted;
 };
 
-module.exports = getExampleLastModifiedDate;
+module.exports = getCoverageAndQualityLastModifiedDate;

--- a/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
+++ b/scripts/pre-build/library/getCoverageAndQualityLastModifiedDate.js
@@ -3,7 +3,7 @@ const getFileLastModifiedDate = require("./getFileLastModifiedDate");
 
 const getCoverageAndQualityLastModifiedDate = async (sourcePath) => {
   const date = await getFileLastModifiedDate(sourcePath);
-  const dateFormatted = format(date, "d MMMM y");
+  const dateFormatted = format(date, "MMMM d, y");
 
   return dateFormatted;
 };

--- a/scripts/pre-build/library/getExampleLastModifiedDate.js
+++ b/scripts/pre-build/library/getExampleLastModifiedDate.js
@@ -1,31 +1,8 @@
-const path = require("path");
-const { exec } = require("child_process");
 const { format } = require("date-fns");
 const { rewriteRelativePath } = require("./rewritePath");
+const getFileLastModifiedDate = require("./getFileLastModifiedDate");
 
 const getExampleLastModifiedDate = async ({ html, sourcePath }) => {
-  const getFileLastModifiedDate = async (sourcePath) => {
-    const output = await new Promise((resolve) => {
-      exec(
-        `git log -1 --pretty="format:%cI" ${path.basename(sourcePath)}`,
-        { cwd: path.dirname(sourcePath) },
-        (error, stdout, stderr) => {
-          resolve(stdout);
-        }
-      );
-    });
-    let date;
-    try {
-      date = new Date(output);
-    } catch (error) {
-      console.error(
-        `Failed to extract a last-modified date for the file "${sourcePath}"`
-      );
-      throw error;
-    }
-    return date;
-  };
-
   const dependencyFilePaths = html
     .querySelectorAll("#css_js_files a")
     .map(

--- a/scripts/pre-build/library/getFileLastModifiedDate.js
+++ b/scripts/pre-build/library/getFileLastModifiedDate.js
@@ -1,0 +1,26 @@
+const path = require("path");
+const { exec } = require("child_process");
+
+const getFileLastModifiedDate = async (sourcePath) => {
+    const output = await new Promise((resolve) => {
+        exec(
+            `git log -1 --pretty="format:%cI" ${path.basename(sourcePath)}`,
+            { cwd: path.dirname(sourcePath) },
+            (error, stdout, stderr) => {
+                resolve(stdout);
+            }
+        );
+    });
+    let date;
+    try {
+        date = new Date(output);
+    } catch (error) {
+        console.error(
+            `Failed to extract a last-modified date for the file "${sourcePath}"`
+        );
+        throw error;
+    }
+    return date;
+};
+
+module.exports = getFileLastModifiedDate;

--- a/scripts/pre-build/library/transformAboutContent.js
+++ b/scripts/pre-build/library/transformAboutContent.js
@@ -25,9 +25,10 @@ const transformAboutContent = async (sourcePath, sourceContents) => {
 
     let paragraphs = html.querySelectorAll("p");
     for (const p of paragraphs) {
+      console.log(p.innerHTML)
       if (!p.innerHTML.includes("Page last updated:")) continue;
       else {
-        p.innerHTML = p.innerHTML.replace(/Page last updated:.*/, `Page last updated: ${lastModifiedDateFormatted}`);
+        p.innerHTML = `Page last updated: ${lastModifiedDateFormatted}`;
         break;
       }
     }

--- a/scripts/pre-build/library/transformAboutContent.js
+++ b/scripts/pre-build/library/transformAboutContent.js
@@ -25,7 +25,6 @@ const transformAboutContent = async (sourcePath, sourceContents) => {
 
     let paragraphs = html.querySelectorAll("p");
     for (const p of paragraphs) {
-      console.log(p.innerHTML)
       if (!p.innerHTML.includes("Page last updated:")) continue;
       else {
         p.innerHTML = `Page last updated: ${lastModifiedDateFormatted}`;

--- a/scripts/pre-build/library/transformAboutContent.js
+++ b/scripts/pre-build/library/transformAboutContent.js
@@ -5,6 +5,7 @@ const removeDuplicateMainTag = require("./removeDuplicateMainTag");
 const rewriteElementPaths = require("./rewriteElementPaths");
 const { rewriteSourcePath } = require("./rewritePath");
 const wrapTablesWithResponsiveDiv = require("./wrapTablesWithResponsiveDiv");
+const getCoverageAndQualityLastModifiedDate = require("./getCoverageAndQualityLastModifiedDate");
 
 const transformAboutContent = async (sourcePath, sourceContents) => {
   const { sitePath, githubPath } = rewriteSourcePath(sourcePath);
@@ -17,6 +18,20 @@ const transformAboutContent = async (sourcePath, sourceContents) => {
   if (isAboutIndexPage) {
     html.querySelector("main ul").classList.add("content-list");
   }
+
+  const isCoverageAndQualityReportPage = sourcePath.endsWith("coverage-and-quality-report.html");
+	if (isCoverageAndQualityReportPage) {
+		const lastModifiedDateFormatted = await getCoverageAndQualityLastModifiedDate(sourcePath);
+
+    let paragraphs = html.querySelectorAll("p");
+    for (const p of paragraphs) {
+      if (!p.innerHTML.includes("Page last updated:")) continue;
+      else {
+        p.innerHTML = p.innerHTML.replace(/Page last updated:.*/, `Page last updated: ${lastModifiedDateFormatted}`);
+        break;
+      }
+    }
+	}
 
   const sidebarWouldBeUseless = html.querySelectorAll("h2").length < 2;
   enableSidebar = !(isAboutIndexPage || sidebarWouldBeUseless);

--- a/scripts/pre-build/library/transformAboutContent.js
+++ b/scripts/pre-build/library/transformAboutContent.js
@@ -20,8 +20,8 @@ const transformAboutContent = async (sourcePath, sourceContents) => {
   }
 
   const isCoverageAndQualityReportPage = sourcePath.endsWith("coverage-and-quality-report.html");
-	if (isCoverageAndQualityReportPage) {
-		const lastModifiedDateFormatted = await getCoverageAndQualityLastModifiedDate(sourcePath);
+  if (isCoverageAndQualityReportPage) {
+    const lastModifiedDateFormatted = await getCoverageAndQualityLastModifiedDate(sourcePath);
 
     let paragraphs = html.querySelectorAll("p");
     for (const p of paragraphs) {
@@ -31,7 +31,7 @@ const transformAboutContent = async (sourcePath, sourceContents) => {
         break;
       }
     }
-	}
+  }
 
   const sidebarWouldBeUseless = html.querySelectorAll("h2").length < 2;
   enableSidebar = !(isAboutIndexPage || sidebarWouldBeUseless);


### PR DESCRIPTION
This PR updates the abountContent transform to include the most recent date for the [coverage-and-quality-report.html file](https://github.com/w3c/aria-practices/blob/main/content/about/coverage-and-quality/coverage-and-quality-report.html) on the page when the website is built. The [preview link for the Coverage and Quality Reports page](https://deploy-preview-311--aria-practices.netlify.app/aria/apg/about/coverage-and-quality/).

https://github.com/w3c/aria-practices/pull/2976 should also be merged when this is.