### PR TITLE
Infrastructure: Remove unexpected `shared/js/app.js` change not yet in w3c/aria-practices

### DIFF
--- a/ARIA/apg/index/index.md
+++ b/ARIA/apg/index/index.md
@@ -67,7 +67,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
     <ul>
       <li><a href="#examples_by_role_label">Examples by Role</a></li>
       <li><a href="#examples_by_props_label">Examples by Properties and States</a></li>
-      
     </ul>
     <section id="examples_by_roles">
       <h2 id="examples_by_role_label">Examples by Role</h2>
@@ -950,7 +949,6 @@ if (enableSidebar) document.body.classList.add('has-sidebar');
           </tr></tbody>
       </table>
     </section>
-    
   </div>
 
 

--- a/content-assets/wai-aria-practices/shared/js/app.js
+++ b/content-assets/wai-aria-practices/shared/js/app.js
@@ -20,20 +20,14 @@
     // Determine we are on an example page
     if (!document.location.href.match(/examples\/[^/]+\.html/)) return;
 
-    const isExperimental =
-      document.querySelector('main')?.getAttribute('data-content-phase') ===
-      'experimental';
-
-    const usageWarningLink = isExperimental
-      ? '/templates/experimental-example-usage-warning.html'
-      : '/templates/example-usage-warning.html';
-
     // Generate the usage warning link using app.js link as a starting point
     const scriptSource = document
       .querySelector('[src$="app.js"]')
       .getAttribute('src');
-
-    const fetchSource = scriptSource.replace('/js/app.js', usageWarningLink);
+    const fetchSource = scriptSource.replace(
+      '/js/app.js',
+      '/templates/example-usage-warning.html'
+    );
 
     // Load and parse the usage warning and insert it before the h1
     const html = await (await fetch(fetchSource)).text();

--- a/scripts/pre-build/library/transformExample.js
+++ b/scripts/pre-build/library/transformExample.js
@@ -12,15 +12,30 @@ const getExampleLastModifiedDate = require("./getExampleLastModifiedDate");
 const loadNoticeCommon = async ({ isExperimental }) => {
   let relativePath;
   if (isExperimental) {
+    // Depends on https://github.com/w3c/aria-practices/pull/2977 being merged
     relativePath =
       "content/shared/templates/experimental-example-usage-warning.html";
   } else {
     relativePath = "content/shared/templates/example-usage-warning.html";
   }
-  const templateSourcePath = path.resolve(sourceRoot, relativePath);
-  const noticeContent = await fs.readFile(templateSourcePath, {
-    encoding: "utf8",
-  });
+
+  let templateSourcePath = path.resolve(sourceRoot, relativePath);
+
+  let noticeContent;
+  try {
+    noticeContent = await fs.readFile(templateSourcePath, {
+      encoding: "utf8",
+    });
+  } catch (e) {
+    console.warn(`${e.message}\nReverting to using default example-usage-warning.html ...\n`);
+
+    // Could happen if experimental-example-usage-warning.html doesn't exist
+    relativePath = "content/shared/templates/example-usage-warning.html";
+    templateSourcePath = path.resolve(sourceRoot, relativePath);
+    noticeContent = await fs.readFile(templateSourcePath, {
+      encoding: "utf8",
+    });
+  }
 
   return async (sourcePath) => {
     const html = parseHtml(noticeContent);


### PR DESCRIPTION
This PR updates this repository to be in sync with files that should only be coming over from w3c/aria-practices. So this removes code automatically synced from `shared/js/app.js` after re-running `node ./scripts/pre-build`.

Additionally, adds file read safety which is important since https://github.com/w3c/aria-practices/pull/2977 has not yet been merged. It has `content/shared/templates/experimental-example-usage-warning.html` which `transformExample.js` looks for with a defined promise.