### PR TITLE
Pin ruby `3.3.3` instead of `3.3.x` during workflow builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: '3.3.3'
         bundler-cache: true
 
     - name: Update git submodules

--- a/.github/workflows/pr-create.yml
+++ b/.github/workflows/pr-create.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: '3.3.3'
 
       - name: Update git submodules
         run: |


### PR DESCRIPTION
Address newly [build errors](https://github.com/w3c/wai-aria-practices/actions/runs/13140249810/job/36665445879) stemming from Ruby 3.3.7 not having the proper file permissions during `bundle install`:

```sh
The installation path is insecure. Bundler cannot continue.
/opt/hostedtoolcache/Ruby/3.3.7/x64/lib/ruby/gems/3.3.0/gems is world-writable
(without sticky bit).
Bundler cannot safely replace gems in world-writeable directories due to
potential vulnerabilities.
Please change the permissions of this directory or choose a different install
path.
```

Bumping bundler to `2.5.19` should resolve this as well but it makes more sense to pin the ruby version here with what's used in `netlify.toml` and the rest of the `wai-website` resources (as it should have been from the start)