### PR TITLE
Create `.tracked-html-assets.json` 

### DIFF
--- a/scripts/pre-build/library/.tracked-html-assets.json
+++ b/scripts/pre-build/library/.tracked-html-assets.json
@@ -1,0 +1,6 @@
+[
+  "feed/examples/feed-display.html",
+  "content\\/patterns\\/landmarks\\/examples\\/.+\\.html",
+  "toolbar/examples/help.html",
+  "color-settings/test-contrast-theme.html"
+]

--- a/scripts/pre-build/library/determineContentType.js
+++ b/scripts/pre-build/library/determineContentType.js
@@ -1,3 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+// Update .tracked-html-assets.json with the paths or regexes to new html assets which don't fall in line with the expected html file naming structures to consider them as valid 'htmlAsset's
+const trackedHtmlAssetsData = fs.readFileSync(path.join(__dirname, '.tracked-html-assets.json'), { encoding: "utf8" })
+const trackedHtmlAssets = JSON.parse(trackedHtmlAssetsData);
+
+const processTrackedHtmlAsset = (sourcePath) => {
+  return trackedHtmlAssets.some(trackedAsset => {
+    if (sourcePath.endsWith(trackedAsset)) return true;
+
+    try {
+      const regexp = new RegExp(trackedAsset);
+      return regexp.test(sourcePath);
+    } catch (e) {
+      return false;
+    }
+  });
+}
+
 const determineContentType = (sourcePath) => {
   if (sourcePath.endsWith("content/apg-home.html")) {
     return "homepage";
@@ -9,13 +29,8 @@ const determineContentType = (sourcePath) => {
   ) {
     return "imageAsset";
   }
-  if (
-    sourcePath.endsWith("feed/examples/feed-display.html") ||
-    sourcePath.match(/content\/patterns\/landmarks\/examples\/.+\.html/) ||
-    sourcePath.endsWith("toolbar/examples/help.html")
-  ) {
-    return "htmlAsset";
-  }
+
+  if (processTrackedHtmlAsset(sourcePath)) return "htmlAsset";
   if (!sourcePath.endsWith("html")) {
     return "otherAsset";
   }
@@ -54,7 +69,7 @@ const determineContentType = (sourcePath) => {
   }
   throw new Error(
     `Could not determine content type for file at ${sourcePath}\n` +
-      `This file may not follow established conventions.`
+    `This file may not follow established conventions.`
   );
 };
 

--- a/scripts/pre-build/library/determineContentType.js
+++ b/scripts/pre-build/library/determineContentType.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
-// Update .tracked-html-assets.json with the paths or regexes to new html assets which don't fall in line with the expected html file naming structures to consider them as valid 'htmlAsset's
+// Update .tracked-html-assets.json with paths or regexes for html assets which don't fall in line with the expected html file naming structures to consider them as valid 'htmlAsset's
 const trackedHtmlAssetsData = fs.readFileSync(path.join(__dirname, '.tracked-html-assets.json'), { encoding: "utf8" })
 const trackedHtmlAssets = JSON.parse(trackedHtmlAssetsData);
 
@@ -69,7 +69,8 @@ const determineContentType = (sourcePath) => {
   }
   throw new Error(
     `Could not determine content type for file at ${sourcePath}\n` +
-    `This file may not follow established conventions.`
+    `This file may not follow established conventions.\n` +
+    `If this is a html file that should be included, please add it to .tracked-html-assets.json.`
   );
 };
 


### PR DESCRIPTION
This PR adds `scripts/pre-build/library/.tracked-html-assets.json` to easily define which html assets that don't support the expected html naming structure can be included.

ie. A pattern called 'sample' would be located at `content/patterns/sample/sample-pattern.html` but there isn't an expectation for there to be `content/patterns/sample/sample-support.html`. Historically, there has been instances of this that have had to be explicitly supported. This helps to slightly manage that restriction.