### PR TITLE
Update netlify.toml to force a cache clearance

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-command = "git submodule update --init --remote && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+# NB rm -rf typically applies to UNIX environments which this Netlify deploy works; a temporary solution to while figuring why .gitmodule updates are causing deploy issues unless cache is reset
+command = "rm -rf .git/modules .git/modules/* .git/index .git/.gitmodules .netlify .cache node_modules build dist out && git submodule update --init --remote && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
 publish = "_site"
 
 [build.environment]


### PR DESCRIPTION
Netlify has removed the option for clearing the cache on each build. This PR attempts to do that manually by removing the likely cache locations during the Netlify branch build.

This is needed because in very specific cases, when the changes coming from `aria-practices` PR is force-pushed onto, it may not successfully rebuild due to 'unknown commits' in the `.gitmodule` folder's contents, unless the Netlify branch deploy is re-ran without the cache option.