### PR TITLE
Adds the "Read This First" banner to each pattern page

### DIFF
--- a/content-assets/wai-aria-practices/styles.css
+++ b/content-assets/wai-aria-practices/styles.css
@@ -989,13 +989,19 @@ table.sortable th button:focus {
   width: 50%;
 }
 
+.read-this-first:not(:has(img)) .text {
+  margin-top: 0;
+  margin-left: 0;
+  margin-bottom: 0;
+}
+
 @media screen and (min-width: 23em) {
   .read-this-first img {
     width: 178px;
   }
 }
 
-@media screen and (min-width: 35em) { 
+@media screen and (min-width: 35em) {
   .read-this-first {
     overflow: visible;
   }
@@ -1007,21 +1013,33 @@ table.sortable th button:focus {
     margin-left: 14em;
     margin-bottom: 0;
   }
+  .read-this-first:not(:has(img)) .text {
+    margin-top: 0;
+    margin-left: 0;
+  }
 }
 
-@media screen and (min-width: 35em) { 
+@media screen and (min-width: 35em) {
   .read-this-first {
     margin-top: 3em;
   }
-
+  .read-this-first:not(:has(img)) {
+    margin-top: 0;
+  }
 }
 
-@media screen and (min-width: 60em) { 
+@media screen and (min-width: 60em) {
   .read-this-first {
     margin-top: 4em;
     padding: 1em;
   }
   .read-this-first .text {
     margin-right: 2em;
+  }
+  .read-this-first:not(:has(img)) {
+    margin-top: 0;
+  }
+  .read-this-first:not(:has(img)) .text {
+    margin-left: 0;
   }
 }

--- a/scripts/pre-build/library/transformPattern.js
+++ b/scripts/pre-build/library/transformPattern.js
@@ -5,8 +5,11 @@ const { parse: parseHtml } = require("node-html-parser");
 const rewriteElementPaths = require("./rewriteElementPaths");
 const removeDuplicateMainTag = require("./removeDuplicateMainTag");
 const removeConflictingCss = require("./removeConflictingCss");
+const { getReadThisFirst } = require("./transformPatternIndex");
 
 const transformPattern = async (sourcePath, sourceContents) => {
+  const readThisFirst = await getReadThisFirst(sourcePath, { includeImage: false });
+
   const { sitePath, githubPath } = rewriteSourcePath(sourcePath);
   const html = parseHtml(sourceContents);
 
@@ -36,11 +39,16 @@ const transformPattern = async (sourcePath, sourceContents) => {
 
   await rewriteElementPaths(html, { onSourcePath: sourcePath });
 
+  const content = `
+    ${readThisFirst}
+    ${removeDuplicateMainTag(html.querySelector("body").innerHTML)}
+  `
+
   return formatForJekyll({
     title,
     sitePath,
     githubPath,
-    content: removeDuplicateMainTag(html.querySelector("body").innerHTML),
+    content,
     enableSidebar: true,
     head: html.querySelector("head"),
     footer: "",

--- a/scripts/pre-build/library/transformPatternIndex.js
+++ b/scripts/pre-build/library/transformPatternIndex.js
@@ -6,11 +6,14 @@ const { rewriteSourcePath, sourceRoot } = require("./rewritePath");
 const removeConflictingCss = require("./removeConflictingCss");
 const rewriteElementPaths = require("./rewriteElementPaths");
 
-const getReadThisFirst = async (sourcePath) => {
+const getReadThisFirst = async (sourcePath, { includeImage = true } = {}) => {
   const relativePath = "content/shared/templates/read-this-first.html";
   const filePath = path.resolve(sourceRoot, relativePath);
   const fileContent = await fs.readFile(filePath, { encoding: "utf8" });
   const html = parseHtml(fileContent);
+
+  if (!includeImage) html.querySelector("img")?.remove();
+
   await rewriteElementPaths(html, {
     onSourcePath: sourcePath,
     optionalTemplateSourcePath: path.join(sourceRoot, relativePath),


### PR DESCRIPTION
Closes https://github.com/w3c/aria-practices/issues/3293

This allows displaying a trimmed (img-less) version of the "Read This First, No ARIA is better than Bad ARIA. Before using any ARIA" banner to each pattern page.

[Contrary to initial discussions when that meeting took place, this change had to happen here, rather than in w3c/aria-practices](https://github.com/w3c/aria-practices/issues/3293#issuecomment-2981528147), because the "Read This First" banner is being injected during this repository's build process.