### PR TITLE
Remove manual cache clear from `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 [build]
-# NB rm -rf typically applies to UNIX environments which this Netlify deploy works; a temporary solution to while figuring why .gitmodule updates are causing deploy issues unless cache is reset
-command = "rm -rf .git/modules .git/modules/* .git/index .git/.gitmodules .netlify .cache node_modules build dist out && git submodule update --init --remote && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+command = "git submodule update --init --remote && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
 publish = "_site"
 
 [build.environment]


### PR DESCRIPTION
Related to #398 

This solution didn't stick based on a [build from July 8 2025](https://app.netlify.com/projects/aria-practices/deploys/686d77ee7b151d00086ee363)