### PR TITLE
For APG publication on May 14, 2026

### DIFF
--- a/ARIA/apg/patterns/accordion/accordion-pattern.md
+++ b/ARIA/apg/patterns/accordion/accordion-pattern.md
@@ -74,7 +74,7 @@ lang: en
       <section id="examples" class="examples-section">
         <img alt src="../../../../content-images/wai-aria-practices/images/pattern-accordion.svg">
         <h2>Example</h2>
-        <p><a href="examples/accordion/">Accordion Example</a>: demonstrates a form divided into three sections using an accordion to show one section at a time.</p>
+        <p><a href="examples/accordion/">Accordion Example</a>: demonstrates using an accordion to divide a form into three expandable sections.</p>
       </section>
 
       <section id="keyboard_interaction">
@@ -95,16 +95,6 @@ lang: en
           </li>
           <li><kbd>Tab</kbd>: Moves focus to the next focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
           <li><kbd>Shift</kbd> + <kbd>Tab</kbd>: Moves focus to the previous focusable element; all focusable elements in the accordion are included in the page <kbd>Tab</kbd> sequence.</li>
-          <li>
-            <kbd>Down Arrow</kbd> (Optional): If focus is on an accordion header, moves focus to the next accordion header.
-            If focus is on the last accordion header, either does nothing or moves focus to the first accordion header.
-          </li>
-          <li>
-            <kbd>Up Arrow</kbd> (Optional): If focus is on an accordion header, moves focus to the previous accordion header.
-            If focus is on the first accordion header, either does nothing or moves focus to the last accordion header.
-          </li>
-          <li><kbd>Home</kbd> (Optional): When focus is on an accordion header, moves focus to the first accordion header.</li>
-          <li><kbd>End</kbd> (Optional): When focus is on an accordion header, moves focus to the last accordion header.</li>
         </ul>
       </section>
 

--- a/ARIA/apg/patterns/alertdialog/alertdialog-pattern.md
+++ b/ARIA/apg/patterns/alertdialog/alertdialog-pattern.md
@@ -77,6 +77,7 @@ lang: en
           <li>
             The element that contains all elements of the dialog, including the alert message and any dialog buttons, has role <a class="role-reference" href="https://w3c.github.io/aria/#alertdialog">alertdialog</a>.
           </li>
+          <li>The dialog container element has <a href="https://w3c.github.io/aria/#aria-modal" class="property-reference">aria-modal</a> set to <code>true</code>.</li>
           <li>
             The element with role <code>alertdialog</code> has either:
             <ul>
@@ -92,6 +93,27 @@ lang: en
             The element with role <code>alertdialog</code> has a value set for <a href="https://w3c.github.io/aria/#aria-describedby" class="property-reference">aria-describedby</a> that refers to the element containing the alert message.
           </li>
         </ul>
+        <div class="note">
+          <h3>Note</h3>
+          <ul>
+            <li>
+              Because marking a dialog modal by setting <a href="https://w3c.github.io/aria/#aria-modal" class="property-reference">aria-modal</a> to <code>true</code> can prevent users of some assistive technologies from perceiving content outside the dialog, users of those technologies will experience severe negative ramifications if a dialog is marked modal but does not behave as a modal for other users.
+              So, mark a dialog modal <strong>only when both:</strong>
+              <ol>
+                <li>Application code prevents all users from interacting in any way with content outside of it.</li>
+                <li>Visual styling obscures the content outside of it.</li>
+              </ol>
+            </li>
+            <li>
+              The <code>aria-modal</code> property introduced by ARIA 1.1 replaces <a href="https://w3c.github.io/aria/#aria-hidden" class="state-reference">aria-hidden</a> for informing assistive technologies that content outside a dialog is inert.
+              However, in legacy dialog implementations where <code>aria-hidden</code> is used to make content outside a dialog inert for assistive technology users, it is important that:
+              <ol>
+                <li><code>aria-hidden</code> is set to <code>true</code> on each element containing a portion of the inert layer.</li>
+                <li>The dialog element is not a descendant of any element that has <code>aria-hidden</code> set to <code>true</code>.</li>
+              </ol>
+            </li>
+          </ul>
+        </div>
       </section>
     </div>
   

--- a/ARIA/apg/patterns/landmarks/examples/resources.html
+++ b/ARIA/apg/patterns/landmarks/examples/resources.html
@@ -57,8 +57,8 @@ permalink: /ARIA/apg/patterns/landmarks/examples/resources.html
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA11">ARIA11: Using ARIA landmarks to identify regions of a page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://www.w3.org/TR/WCAG20-TECHS/aria#ARIA20">ARIA20: Using the region role to identify a region of the page</a> (WCAG 2.0 Technique)</li>
                             <li><a href="https://alistapart.com/column/wai-finding-with-aria-landmark-roles">WAI-finding with ARIA Landmark Roles</a> (A List Apart)</li>
-                            <li><a href="https://www.paciellogroup.com/blog/2013/02/using-wai-aria-landmarks-2013/">Using WAI-ARIA Landmarks – 2013</a> (Paciello Group)</li>
-                            <li><a href="https://www.paciellogroup.com/blog/2015/01/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Paciello Group)</li>
+                            <li><a href="https://vispero.com/resources/using-wai-aria-landmark-roles/">Using WAI-ARIA Landmarks – updated</a> (Vispero)</li>
+                            <li><a href="https://vispero.com/resources/basic-screen-reader-commands-for-accessibility-testing/">Basic screen reader commands for accessibility testing</a>  (Vispero)</li>
                             <li><a href="http://webaim.org/projects/screenreadersurvey9/#landmarks">Screen Reader User Survey #9 Results: Landmarks/Regions</a> (WebAIM)</li>
                           </ul>
                         </section>

--- a/ARIA/apg/practices/keyboard-interface/keyboard-interface-practice.md
+++ b/ARIA/apg/practices/keyboard-interface/keyboard-interface-practice.md
@@ -426,9 +426,9 @@ lang: en
       <section id="kbd_disabled_controls">
         <h2>Focusability of disabled controls</h2>
         <p>
-          By default, disabled HTML input elements are removed from the tab sequence.
-          In most contexts, the normal expectation is that disabled interactive elements are not focusable.
-          However, there are some contexts where it is common for disabled elements to be focusable, especially inside of composite widgets.
+          Browsers remove HTML input elements with the <code>disabled</code> attribute from the tab sequence.
+          However, there are some contexts where it is useful for an element to convey a disabled state while remaining focusable, especially inside of composite widgets.
+          This can be accomplished by applying the state <code>aria-disabled="true"</code>.
           For example, as demonstrated in the
           <a href="../../patterns/menubar/">menu and menubar pattern</a>,
           disabled items are focusable when navigating through a menu with the arrow keys.
@@ -437,21 +437,41 @@ lang: en
         <p>
           Removing focusability from disabled elements can offer users both advantages and disadvantages.
           Allowing keyboard users to skip disabled elements usually reduces the number of key presses required to complete a task.
-          However, preventing focus from moving to disabled elements can hide their presence from screen reader users who "see" by moving the focus.
+          However, screen reader users are far less likely to discover disabled elements that are not focusable because moving focus is one of their primary methods of discovery.
         </p>
 
         <p>
-          Authors are encouraged to adopt a consistent set of conventions for the focusability of disabled elements.
+Authors are encouraged to adopt consistent pattern-based conventions for the focusability of disabled elements.
           The examples in this guide adopt the following conventions, which both reflect common practice and attempt to balance competing concerns.
         </p>
-
         <ol>
-          <li>For elements that are in the tab sequence when enabled, remove them from the tab sequence when disabled.</li>
+          <li>
+            When users can reasonably infer the presence of a disabled element from nearby
+            focusable elements, it is removed from the keyboard focus order
+            using the HTML <code>disabled</code> attribute. For example:
+            <ul>
+              <li>
+                In the <a href="../../patterns/grid/examples/layout-grids/#ex3_label">“Scrollable
+                Search Results” grid example</a>, when the grid is showing the
+                first page and the “Next” button receives focus, users can infer
+                that the “Previous” button is disabled.
+              </li>
+              <li>
+                A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
+                The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
+                Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
+              </li>
+            </ul>
+          </li>
 
           <li>
-            For the following composite widget elements, keep them focusable when disabled:
-
+            When a disabled element <em>does</em> need to remain discoverable, <code>aria-disabled="true"</code> is applied so that it will remain focusable. For example:
             <ul>
+              <li>
+                The “Copy”, “Cut”, and “Paste” buttons in the <a href="../../patterns/toolbar/examples/toolbar/">Toolbar</a>.
+                The discoverability of these features relies on their focusability even when they are not immediately applicable
+                (i.e., when no text is selected in the editor and/or when the clipboard is empty).
+              </li>
               <li>Options in a <a href="../../patterns/listbox/">Listbox</a></li>
               <li>Menu items in a <a href="../../patterns/menubar/">Menu or menu bar</a></li>
               <li>Tab elements in a set of <a href="../../patterns/tabs/">Tabs</a></li>
@@ -459,23 +479,6 @@ lang: en
             </ul>
           </li>
 
-          <li>
-            For elements contained in a toolbar, make them focusable if discoverability is a concern.
-            Here are two examples to aid with this judgment.
-
-            <ol>
-              <li>
-                A toolbar with buttons for moving, removing, and adding items in a list includes buttons for &quot;Up&quot;, &quot;Down&quot;, &quot;Add&quot;, and &quot;Remove&quot;.
-                The &quot;Up&quot; button is disabled and its focusability is removed when the first item in the list is selected.
-                Given the presence of the &quot;Down&quot; button, discoverability of the &quot;Up&quot; button is not a concern.
-              </li>
-
-              <li>
-                A toolbar in an editor contains a set of special smart paste functions that are disabled when the clipboard is empty or when the function is not applicable to the current content of the clipboard.
-                It could be helpful to keep the disabled buttons focusable if the ability to discover their functionality is primarily via their presence on the toolbar.
-              </li>
-            </ol>
-          </li>
         </ol>
 
         <p>One design technique for mitigating the impact of including disabled elements in the path of keyboard focus is employing appropriate keyboard shortcuts as described in <a href="#kbd_shortcuts">Keyboard Shortcuts</a>.</p>


### PR DESCRIPTION
This PR includes the following changes that have been merged to main in w3c/aria-practices.

## Landmarks Examples Resources Page: Update broken TPGI links (pull #3425)

By Adam Page on Sat Apr 4 17:20:03 2026 -0700

* update TPGi domain links to Vispero.com
* add Vispero to cspell allow list

[View commit b5c817dd](http://github.com/w3c/aria-practices/commit/b5c817ddc922d0476a8c273dd2e03f55f9070cce)

## Developing a Keyboard Interface Practice: Clarify guidance for Focusability of disabled Controls (pull #3387)

By Adam Page on Wed Apr 29 06:14:37 2026 -0700

Resolves issue #2318 with editorial clarifications. The changes are intended to better help readers understand that:
* Author judgment is required to design effective focus sequences.
* How to make those judgments with respect to the focusability of disabled elements.

---------

Co-authored-by: Matt King <a11yThinker@Gmail.com>
Co-authored-by: Daniel Montalvo <49305434+daniel-montalvo@users.noreply.github.com>

[View commit e1a5f384](http://github.com/w3c/aria-practices/commit/e1a5f384c8c302d4576fb40ea71c4e4d1269af42)

## AlertDialog Pattern: Add guidance about use of aria-modal attribute (pull #3421)

By nakajima a.k.a. nazomikan on Wed Apr 29 22:48:05 2026 +0900

Editorial addition to the alert dialog pattern that includes guidance that had already been provided in the modal dialog pattern, making the two patterns more consistent with one another.

[View commit a4cfe32d](http://github.com/w3c/aria-practices/commit/a4cfe32d25412299d2e77a336307e12e3472be38)

## Accordion Pattern: Remove optional arrow, home, and end keys (#3434)

By Matt King on Wed Apr 29 06:51:16 2026 -0700

Resolves issue #3406 with the following changes to the keyboard section of the pattern:
1. Remove guidance for optionally implementing support for up and down arrow keys.
2. Remove guidance for optionally implementing support for Home and End arrow keys.

In addition, makes a minor editorial revision to the description of the example. When the example was originally implemented, it allowed only one section to be expanded at a time. Later it was changed to support expansion of multiple sections simultaneously, but the description of the example on the pattern page was not revised to reflect that change. This change aligns the description with the current behavior.

[View commit 7b134ce6](http://github.com/w3c/aria-practices/commit/7b134ce6d19497cce8a67db4a9f59980baf853dc)