### PR TITLE
Upgrade actions to recent versions relying on Node v24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         cache: npm
         cache-dependency-path: scripts/pre-build/package-lock.json
@@ -36,7 +36,7 @@ jobs:
         node ./scripts/pre-build
 
     - name: Commit changed files and submodule updates
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_user_name: w3cgruntbot
         commit_user_email: w3cgruntbot@users.noreply.github.com

--- a/.github/workflows/pr-create.yml
+++ b/.github/workflows/pr-create.yml
@@ -28,13 +28,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: pr-create
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: npm
           cache-dependency-path: scripts/pre-build/package-lock.json
@@ -143,7 +143,7 @@ jobs:
 
       - name: Commit changed files and submodule updates
         if: steps.update_site_files.outcome == 'success'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_user_name: w3cgruntbot
           commit_user_email: w3cgruntbot@users.noreply.github.com

--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check if branch exists
         id: check_if_exists


### PR DESCRIPTION
This resolves warnings about actions that rely on Node v20.

I test-ran all of the workflows on my fork (minus the last step of the pr-create workflow which doesn't depend on any actions) with this branch to confirm they all still run as expected.