### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,21 +6,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:
         submodules: true
         fetch-depth: 0
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
       with:
         cache: npm
         cache-dependency-path: scripts/pre-build/package-lock.json
 
     - name: Set up Ruby 3.4.8
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b #v1.321.0
       with:
         ruby-version: '3.4.8'
         bundler-cache: true
@@ -36,11 +38,11 @@ jobs:
         node ./scripts/pre-build
 
     - name: Commit changed files and submodule updates
-      uses: stefanzweifel/git-auto-commit-action@v7
+      uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d #v7.2.0
       with:
-        commit_user_name: w3cgruntbot
-        commit_user_email: w3cgruntbot@users.noreply.github.com
-        commit_author: w3cgruntbot <w3cgruntbot@users.noreply.github.com>
+        commit_user_name: github-actions[bot]
+        commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+        commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         commit_message: "chore: Update `main` with latest changes from `aria-practices`"
         branch: main
       env:

--- a/.github/workflows/pr-create.yml
+++ b/.github/workflows/pr-create.yml
@@ -20,27 +20,31 @@ jobs:
   pr-create:
     runs-on: ubuntu-latest
 
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Get current job and log url
-        uses: Tiryoh/gha-jobid-action@v1
+        uses: Tiryoh/gha-jobid-action@be260d8673c9211a84cdcf37794ebd654ba81eef #v1.4.O
         id: jobs
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: pr-create
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
         with:
           submodules: true
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v7.0.0
         with:
           cache: npm
           cache-dependency-path: scripts/pre-build/package-lock.json
 
       - name: Set up Ruby 3.4.8
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b #v1.321.0
         with:
           ruby-version: '3.4.8'
 
@@ -77,8 +81,8 @@ jobs:
 
       - name: Force rebase the switched branch onto main
         run: |
-          git config --global user.name "w3cgruntbot"
-          git config --global user.email "w3cgruntbot@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main
           git rebase --force-rebase origin/main || true
 
@@ -129,8 +133,6 @@ jobs:
           done
 
           echo "No submodule conflicts detected or no rebase in progress"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update site files
         id: update_site_files
@@ -145,14 +147,12 @@ jobs:
         if: steps.update_site_files.outcome == 'success'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_user_name: w3cgruntbot
-          commit_user_email: w3cgruntbot@users.noreply.github.com
-          commit_author: w3cgruntbot <w3cgruntbot@users.noreply.github.com>
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit_message: 'chore: Update branch with latest `${{ github.event.inputs.apg_branch }}` changes and submodule updates'
           branch: apg/${{ github.event.inputs.apg_branch }}
           push_options: '--force'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update pull request
         working-directory: ./

--- a/.github/workflows/remove-branch.yml
+++ b/.github/workflows/remove-branch.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   remove-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
       - name: Check if branch exists
         id: check_if_exists
@@ -24,8 +27,8 @@ jobs:
         if: ${{ steps.check_if_exists.outputs.BRANCH_EXISTS == '1' }}
         run: |
           BRANCH_NAME="apg/${{ github.event.inputs.apg_branch }}"
-          git config --global user.name "w3cgruntbot"
-          git config --global user.email "w3cgruntbot@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git push origin --delete $BRANCH_NAME
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- pins actions to a full-length commit SHA, following GitHub's recommendations
- bumps `checkout` from v6 to v7.0.1
- bumps `setup-node` from v6 to v7.0.0
- sets more specific permissions
- updates commit user name and email address for commits created via GitHub actions

All workflows were tested successfully in forks.